### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,20 +22,8 @@ This module is really just about making it work with Nuxt 3 without the need to 
 
 ## Quick Setup
 
-1. Add `nuxt3-leaflet` dependency to your project
-
 ```bash
 npx nuxi@latest module add nuxt3-leaflet
-```
-
-2. Add `nuxt3-leaflet` to the `modules` section of `nuxt.config.ts`
-
-```js
-export default defineNuxtConfig({
-  modules: [
-    'nuxt3-leaflet'
-  ]
-})
 ```
 
 That's it! You can now use Leaflet in your Nuxt app ✨

--- a/README.md
+++ b/README.md
@@ -25,14 +25,7 @@ This module is really just about making it work with Nuxt 3 without the need to 
 1. Add `nuxt3-leaflet` dependency to your project
 
 ```bash
-# Using pnpm
-pnpm add -D nuxt3-leaflet
-
-# Using yarn
-yarn add --dev nuxt3-leaflet
-
-# Using npm
-npm install --save-dev nuxt3-leaflet
+npx nuxi@latest module add nuxt3-leaflet
 ```
 
 2. Add `nuxt3-leaflet` to the `modules` section of `nuxt.config.ts`


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
